### PR TITLE
minLength

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -156,7 +156,7 @@ In den key 'additional_data' kann ein JSON-Objekt mit weiteren Daten geschrieben
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -240,7 +240,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -263,7 +263,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -415,7 +415,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -445,7 +445,8 @@ Unknown type `object`.
   "properties": {
     "name": {
       "title": "Name des Verlages",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "publisher_ids": {
       "type": "array",
@@ -500,7 +501,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -523,7 +524,7 @@ Titel der Zeitschrift
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -546,7 +547,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -641,7 +642,7 @@ Array type: `string[]`
 All items must be of the type:
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -653,7 +654,7 @@ All items must be of the type:
 ## other_ids
 ### weitere IDs
 
-Weitere Identifier aus dem Quelldatensatz mit Angabe des Typs der ID, z.B. doi, urn, oai_id usw. Vergleiche http://swbtools.bsz-bw.de/cgi-bin/help.pl?cmd=kat&val=2113&regelwerk=RDA&verbund=GBV
+Weitere Identifier aus dem Quelldatensatz mit Angabe des Typs der ID, z.B. doi, urn, oai_id usw. (hier keine Identifier zu Zeitschriften, Personen usw.) Vergleiche http://swbtools.bsz-bw.de/cgi-bin/help.pl?cmd=kat&val=2113&regelwerk=RDA&verbund=GBV
 
 `other_ids`
 
@@ -801,7 +802,8 @@ Unknown type `object`.
     "name": {
       "type": "string",
       "title": "Name der Einrichtung",
-      "description": "Name der Einrichtung"
+      "description": "Name der Einrichtung",
+      "minLength": 1
     },
     "affiliation_ids": {
       "type": "array",
@@ -859,7 +861,7 @@ Vorname
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -882,7 +884,7 @@ persönlicher Name, dieser wird auch verwendet, wenn eine Aufteilung in Nachname
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -905,7 +907,7 @@ Nachname
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1019,7 +1021,7 @@ Rolle der Person in Bezug auf den Artikel als relator code nach https://opus.k10
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1119,7 +1121,7 @@ oai_id
 ```
 
 ```json
-https://gso.gbv.de/DB=2.1/
+https://kxp.k10plus.de/DB=2.1/
 ```
 
 ```json
@@ -1175,7 +1177,7 @@ Eventuelle Ergänzung zum Haupttitel
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1281,7 +1283,7 @@ Array type: `string[]`
 All items must be of the type:
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1313,7 +1315,7 @@ Der Haupttitel des Artikels
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1415,7 +1417,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1487,7 +1489,7 @@ All instances must conform to this regular expression
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1507,7 +1509,7 @@ All instances must conform to this regular expression
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1653,7 +1655,7 @@ All instances must conform to this regular expression
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1698,7 +1700,7 @@ undefined
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1808,7 +1810,7 @@ gnd
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 
@@ -1828,7 +1830,7 @@ gnd
 
 `string`
 
-
+* minimum length: 1 characters
 
 
 

--- a/article_schema.json
+++ b/article_schema.json
@@ -23,7 +23,8 @@
         "title": {
           "title": "Titel",
           "description": "Titel der Zeitschrift",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "journal_ids": {
           "title": "IDs der Zeitschrift",
@@ -48,7 +49,7 @@
                 "type": "string",
                 "minLength": 1,
                 "examples": [
-		  "coden",
+                  "coden",
                   "eissn",
                   "pissn",
                   "zdbid"
@@ -77,11 +78,13 @@
         },
         "volume": {
           "title": "Band",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "issue": {
           "title": "Ausgabe",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "publisher": {
           "type": "object",
@@ -90,7 +93,8 @@
           "properties": {
             "name": {
               "title": "Name des Verlages",
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             },
             "publisher_ids": {
               "type": "array",
@@ -123,15 +127,18 @@
         },
         "place": {
           "title": "Erscheinungsort",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "start_page": {
           "title": "Anfangsseite",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         },
         "end_page": {
           "title": "Endseite",
-          "type": "string"
+          "type": "string",
+          "minLength": 1
         }
       }
     }
@@ -198,19 +205,22 @@
     "title": {
       "type": "string",
       "title": "Titel",
-      "description": "Der Haupttitel des Artikels"
+      "description": "Der Haupttitel des Artikels",
+      "minLength": 1
     },
     "subTitle": {
       "type": "string",
       "title": "Titel",
-      "description": "Eventuelle Ergänzung zum Haupttitel"
+      "description": "Eventuelle Ergänzung zum Haupttitel",
+      "minLength": 1
     },
     "otherTitles": {
       "type": "array",
       "title": "Weitere Titel",
       "description": "Weitere Titelformen",
       "items": {
-        "type": "string"
+        "type": "string",
+        "minLength": 1
       }
     },
     "persons": {
@@ -226,22 +236,26 @@
           "fullname": {
             "type": "string",
             "title": "Voller Name",
-            "description": "persönlicher Name, dieser wird auch verwendet, wenn eine Aufteilung in Nachname, Vorname nicht möglich ist. Verfassende Organisationen (Körperschaften) können bei Aufsätzen auch als „persönlicher Name“ angegeben werden"
+            "description": "persönlicher Name, dieser wird auch verwendet, wenn eine Aufteilung in Nachname, Vorname nicht möglich ist. Verfassende Organisationen (Körperschaften) können bei Aufsätzen auch als „persönlicher Name“ angegeben werden",
+            "minLength": 1
           },
           "firstname": {
             "type": "string",
             "title": "Vorname",
-            "description": "Vorname"
+            "description": "Vorname",
+            "minLength": 1
           },
           "lastname": {
             "type": "string",
             "title": "Nachname",
-            "description": "Nachname"
+            "description": "Nachname",
+            "minLength": 1
           },
           "role": {
             "type": "string",
             "title": "role",
             "description": "Rolle der Person in Bezug auf den Artikel als relator code nach https://opus.k10plus.de/frontdoor/deliver/index/docId/421/file/Liste_Beziehungskennzeichnungen_3010_3110.pdf",
+            "minLength": 1,
             "examples": [
               "aut",
               "edt",
@@ -256,7 +270,8 @@
               "name": {
                 "type": "string",
                 "title": "Name der Einrichtung",
-                "description": "Name der Einrichtung"
+                "description": "Name der Einrichtung",
+                "minLength": 1
               },
               "affiliation_ids": {
                 "type": "array",
@@ -357,7 +372,8 @@
         "properties": {
           "url": {
             "title": "URL",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "scope": {
             "title": "Bezugswerk",
@@ -382,7 +398,8 @@
         "properties": {
           "text": {
             "title": "Text des Abstracts",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "lang_code": {
             "title": "Sprachcode",
@@ -409,7 +426,8 @@
             "description": "Sacherschließungsterme als Array, jeder Term als eigenes Feld",
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "string",
+              "minLength": 1
             }
           },
           "scheme": {
@@ -429,7 +447,8 @@
     "copyright": {
       "title": "Copyrightvermerk",
       "description": "",
-      "type": "string"
+      "type": "string",
+      "minLength": 1
     },
     "additional_data": {
       "type": "object",

--- a/article_schema.json
+++ b/article_schema.json
@@ -433,7 +433,8 @@
           "scheme": {
             "title": "Sacherschließungssystem",
             "description": "Bezeichnung des Sacherschließungssystems",
-            "type": "string"
+            "type": "string",
+            "minLength": 1
           },
           "lang_code": {
             "title": "Sprachcode",


### PR DESCRIPTION
Es haben nun alle Strings entweder ein Pattern oder minLength = 1. Ausnahme: urls->access_info. Das ist "required" in urls, aber ich denke, dass es da nicht immer eine Angabe geben wird? Oder können wir davon ausgehen, dass das immer sinnvoll belegt sein wird?
Falls nicht gibt es zwei Alternativen: minLength = 1, dann aber nicht mehr "required"?
Oder so lassen, wie es ist?

Bei urls->scope erlaubt das Pattern ^$|^[0-9][0-9]$ sogar explizit eine leere Zeichenkette oder zwei Ziffern. Das ist auch "required". Auch da stellt sich die Frage, ob wir da wirklich leere Zeichenketten zulassen wollen oder es aus "required" rausnehmen?