### PR TITLE
"required" bei abstracts: text

### DIFF
--- a/article_schema.json
+++ b/article_schema.json
@@ -395,6 +395,9 @@
       "type": "array",
       "items": {
         "type": "object",
+        "required": [
+          "text"
+        ],
         "properties": {
           "text": {
             "title": "Text des Abstracts",


### PR DESCRIPTION
Wenn es eine Abstract gibt, muss ein text des Abstracts vorhanden sein