### PR TITLE
rückwärtskopatible Erweiterungen des Schemas

### DIFF
--- a/article_schema.json
+++ b/article_schema.json
@@ -202,6 +202,37 @@
         }
       }
     },
+    "collection_ids": {
+      "type": "array",
+      "title": "IDs von Datensammlungen",
+      "description": "Datensätze können über diese IDs bestehenden Datensammlungen zugeordnet werden. Verwendung bitte je Projket mit der Verbundzentrale (VZG) abklären. Beispiele: SSG-Nummer/FID-Kennzeichen, Produktsigel usw.",
+      "items": {
+        "type": "object",
+        "required": [
+          "id",
+          "type"
+        ],
+        "properties": {
+          "id": {
+            "title": "ID",
+            "description": "Wert der ID",
+            "type": "string",
+            "minLength": 1
+          },
+          "type": {
+            "type": "string",
+            "minLength": 1,
+            "title": "Typ",
+            "description": "Typ der ID. Falls unkbekannt: unknown",
+            "examples": [
+              "sigel",
+              "fid",
+              "ssg"
+            ]
+          }
+        }
+      }
+    },    
     "title": {
       "type": "string",
       "title": "Titel",

--- a/article_schema.json
+++ b/article_schema.json
@@ -205,7 +205,7 @@
     "collection_ids": {
       "type": "array",
       "title": "IDs von Datensammlungen",
-      "description": "Datensätze können über diese IDs bestehenden Datensammlungen zugeordnet werden. Verwendung bitte je Projket mit der Verbundzentrale (VZG) abklären. Beispiele: SSG-Nummer/FID-Kennzeichen, Produktsigel usw.",
+      "description": "Datensätze können über diese IDs bestehenden Datensammlungen zugeordnet werden. Verwendung bitte je Projekt mit der Verbundzentrale (VZG) abklären. Beispiele: SSG-Nummer/FID-Kennzeichen, Produktsigel usw.",
       "items": {
         "type": "object",
         "required": [
@@ -418,7 +418,7 @@
             "type": "string"
           },
           "remarks": {
-            "title": "Allgemeine Bermerkung",
+            "title": "Allgemeine Bemerkung",
             "description": "Bemerkungen zur URL als Text, die in PICA3-Feld 4950 $z abgelegt werden",
             "type": "string"
           }

--- a/article_schema.json
+++ b/article_schema.json
@@ -385,6 +385,11 @@
             "title": "Codierte Zugangsbedingungen",
             "description": "Hier werden Zugangsbedingungen (z.B. Open Access) codiert gemäß Katalogisierungsrichtlinie für PICA3 4085 $4: http://swbtools.bsz-bw.de/cgi-bin/help.pl?cmd=kat&val=4085&regelwerk=RDA&verbund=GBV#$4",
             "type": "string"
+          },
+          "remarks": {
+            "title": "Allgemeine Bermerkung",
+            "description": "Bemerkungen zur URL als Text, die in PICA3-Feld 4950 $z abgelegt werden",
+            "type": "string"
           }
         }
       }


### PR DESCRIPTION
- zusätzliches Attribut "remarks" für URLs: Bemerkungen zur URL als Text, die in PICA3-Feld 4950 $z abgelegt werden
- neues Array "collection_ids", in dem Datensätze bestehenden Datensammlungen im CBS zugeordnet werden können (z.B. über ZDB-Sigel, FID-Kennzeichen usw.